### PR TITLE
fix: npm run build output이 생성되도록 수정

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
 # What's changed?
 
+# Why did you make this change?
+
 # Please share your test code result!

--- a/vue.config.js
+++ b/vue.config.js
@@ -18,8 +18,8 @@ module.exports = {
   },
   chainWebpack: (webpackConfig) => {
     webpackConfig.output
-      .filename(`js/[name].[hash:8].js`)
-      .chunkFilename(`js/[name].[hash:8].js`);
+      .filename(`./assets/js/[name].[hash:8].js`)
+      .chunkFilename(`./assets/js/[name].[hash:8].js`);
     webpackConfig
       .plugin('stylelint-webpack-plugin')
       .use('stylelint-webpack-plugin')


### PR DESCRIPTION
# What's changed?
로컬에서의 npm run build 명령어가 output을 만들도록 수정

# Please share your test code result!
<img width="251" alt="Screen Shot 2022-02-27 at 6 48 46 PM" src="https://user-images.githubusercontent.com/63729090/155877509-de40b1e8-4689-41f3-b40b-480df0e92515.png">

