### PR TITLE
fix: default config 내용을 직접 기입하도록 하고, docker-compose entrypoint를 수정합니다.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ RUN npm install
 COPY . /app
 
 # Docker Demon Port Mapping
-EXPOSE $API_PORT
-EXPOSE $WEB_PORT
+EXPOSE 8081
+EXPOSE 8080

--- a/config/default.js
+++ b/config/default.js
@@ -1,35 +1,20 @@
-const {
-  API_PORT_LOCAL,
-  API_BASE_URL_LOCAL,
-  WEB_PORT_LOCAL,
-  WEB_BASE_URL_LOCAL,
-  MYSQL_PORT,
-  MYSQL_ROOT_PASSWORD,
-  MYSQL_DATABASE,
-  MYSQL_USER,
-  MYSQL_PASSWORD,
-  LANG,
-  HOSTNAME,
-  DATABASE_URL,
-} = process.env;
-
 module.exports = {
   api: {
-    baseUrl: API_BASE_URL_LOCAL,
-    port: API_PORT_LOCAL,
+    baseUrl: 'localhost',
+    port: 8081,
   },
   web: {
-    baseUrl: WEB_BASE_URL_LOCAL,
-    port: WEB_PORT_LOCAL,
+    baseUrl: 'localhost',
+    port: 8080,
   },
   mysql: {
     client: 'mysql2',
     connection: {
-      host: HOSTNAME,
-      port: MYSQL_PORT,
-      user: MYSQL_USER,
-      password: MYSQL_ROOT_PASSWORD,
-      database: MYSQL_DATABASE,
+      host: 'localhost',
+      port: 3306,
+      user: 'root',
+      password: 'root',
+      database: 'hm_local',
       charset: 'utf8mb4',
       timezone: 'Z',
       decimalNumbers: true,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     ports:
       - '3306:3306'
     healthcheck:
-      test: mysql --user=${MYSQL_USER} --password=${MYSQL_ROOT_PASSWORD} ${MYSQL_DATABASE} -e 'select 1';
+      test: mysql --user=root --password=root hm_local -e 'select 1';
       interval: 1s
       timeout: 3s
       retries: 30
@@ -25,7 +25,7 @@ services:
     ports:
       - '6379:6379'
     healthcheck:
-      test: ['CMD', 'redis-cli', 'ping']
+      test: [ 'CMD', 'redis-cli', 'ping' ]
       interval: 1s
       timeout: 3s
       retries: 30
@@ -41,5 +41,5 @@ services:
     env_file:
       - .env
     ports:
-      - ${API_PORT_LOCAL}:${API_PORT_LOCAL}
-      - ${WEB_PORT_LOCAL}:${WEB_PORT_LOCAL}
+      - 8081:8081
+      - 8080:8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     ports:
       - '6379:6379'
     healthcheck:
-      test: [ 'CMD', 'redis-cli', 'ping' ]
+      test: ['CMD', 'redis-cli', 'ping']
       interval: 1s
       timeout: 3s
       retries: 30
@@ -36,7 +36,7 @@ services:
       redis:
         condition: service_healthy
     build: .
-    entrypoint: sh -c "cd api ; npm run lint ; npm run test ; cd .. ; npm run test ; npm run lint ; npm run build ; npm run serve:api & npm run serve:web"
+    entrypoint: sh -c "npm run build ; npm run serve:api & npm run serve:web"
     restart: unless-stopped
     env_file:
       - .env


### PR DESCRIPTION
# What's changed?
1. 로컬 환경변수는 .env가 아닌 코드상에 기입하도록 수정
2. docker-compose에서 테스트코드, 린트 체크 제거

# Why did you make this change?
1. critical한 정보가 없음에 비해 .env 관리가 불편
2. 테스트, 린트는 ci 에서 처리했으므로 불필요하다고 생각.

# Please share your test code result!
