### PR TITLE
feat: users & products 도메인 테이블 마이그레이션 작성

### DIFF
--- a/api/migrations/20220303164113_categories.js
+++ b/api/migrations/20220303164113_categories.js
@@ -1,0 +1,29 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.raw(`
+    CREATE TABLE categories (
+      id INT unsigned NOT NULL AUTO_INCREMENT,
+      title VARCHAR(255) NOT NULL COMMENT '카테고리명',
+      price INT unsigned NOT NULL DEFAULT '0' COMMENT '카테고리 기준 가격',
+      parent_id INT unsigned COMMENT '부모 카테고리',
+      PRIMARY KEY (id),
+
+      CONSTRAINT categories_parent_id_foreign 
+      FOREIGN KEY (parent_id) 
+      REFERENCES categories (id)
+    )
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.raw(`
+    DROP TABLE \`categories\`
+  `);
+};

--- a/api/migrations/20220304143336_users.js
+++ b/api/migrations/20220304143336_users.js
@@ -1,0 +1,24 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.raw(`
+    CREATE TABLE users (
+      id INT unsigned NOT NULL AUTO_INCREMENT,
+      type VARCHAR(255) NOT NULL COMMENT '사용자 유형',
+      phone_number VARCHAR(255) NOT NULL COMMENT '사용자 전화번호',
+      PRIMARY KEY (id)
+    )
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.raw(`
+    DROP TABLE \`users\`
+  `);
+};

--- a/api/migrations/20220304144138_products.js
+++ b/api/migrations/20220304144138_products.js
@@ -1,0 +1,29 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.raw(`
+    CREATE TABLE products (
+      id INT unsigned NOT NULL AUTO_INCREMENT,
+      title VARCHAR(255) NOT NULL COMMENT '상품명',
+      is_available BOOL NOT NULL COMMENT '상품 거래 가능 여부',
+      category_id INT unsigned COMMENT '상품 카테고리',
+      PRIMARY KEY (id),
+
+      CONSTRAINT products_category_id_foreign 
+      FOREIGN KEY (category_id) 
+      REFERENCES categories (id)
+    )
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.raw(`
+    DROP TABLE \`products\`
+  `);
+};

--- a/api/migrations/20220304145239_product_options.js
+++ b/api/migrations/20220304145239_product_options.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.raw(`
+    CREATE TABLE product_options (
+      id INT unsigned NOT NULL AUTO_INCREMENT,
+      title VARCHAR(255) NOT NULL COMMENT '상품 옵션 이름',
+      description VARCHAR(255) COMMENT '상품 옵션 설명',
+      is_available BOOL COMMENT '상품 옵션 거래 가능 여부',
+      PRIMARY KEY (id)
+    )
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.raw(`
+    DROP TABLE \`product_options\`
+  `);
+};

--- a/api/migrations/20220304155506_product_product_options.js
+++ b/api/migrations/20220304155506_product_product_options.js
@@ -1,0 +1,32 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  await knex.schema.raw(`
+    CREATE TABLE product_product_options (
+      id INT unsigned NOT NULL AUTO_INCREMENT,
+      product_id INT unsigned NOT NULL,
+      product_options_id INT unsigned NOT NULL,
+      PRIMARY KEY (id),
+
+      CONSTRAINT product_product_options_product_id
+      FOREIGN KEY (product_id)
+      REFERENCES products (id),
+
+      CONSTRAINT product_product_options_product_options_id
+      FOREIGN KEY (product_options_id)
+      REFERENCES product_options (id)
+    )
+  `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.raw(`
+    DROP TABLE \`product_product_options\`
+  `);
+};


### PR DESCRIPTION
# What's changed?
users 테이블과 products 도메인 테이블 마이그레이션 추가

# Why did you make this change?
- 처음 의논하기로는 customers였지만, 주인장 동생도 포함되어야 해서 users 로 네이밍을 바꿀까 합니다.
- stock 관련 컬럼은 주인장이 관리하기 귀찮다 거부하여 제거하였습니다. 🥲

# Please share your test code result!
<img width="311" alt="Screen Shot 2022-03-05 at 1 03 51 AM" src="https://user-images.githubusercontent.com/63729090/156797623-3dc5bd23-444c-40b9-94a6-975f75eba756.png">

