### PR TITLE
fix: api 디렉토리에서 build, serve시 default 수행값 제공

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -11,7 +11,9 @@
     "migrate:down": "knex migrate:down",
     "clean": "rimraf ./node_modules",
     "test": "jest --detectOpenHandles --forceExit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "build": "echo no build",
+    "serve": "npm start"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
# What's changed?
api 디렉토리에서 npm run, npm build시 수행값 제공

# Why did you make this change?
실수로 api 디렉토리에서 빌드할때에 문제가 생긴다는 제보가...

# Please share your test code result!
